### PR TITLE
Use parse_int helper for integer coercion

### DIFF
--- a/core/__init__.py
+++ b/core/__init__.py
@@ -1,0 +1,1 @@
+# Package marker

--- a/core/loaders.py
+++ b/core/loaders.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 import pandas as pd
 from typing import List
 from .schema import normalize_headers
-from .transforms import parse_price, parse_percent, coerce_numeric, ensure_country_column
+from .transforms import parse_price, parse_percent, parse_int, coerce_numeric, ensure_country_column
 from .config import PRICE_COLS, PCT_COLS, INT_COLS
 
 def read_any(path_or_file):
@@ -18,7 +18,7 @@ def load_many(files: List) -> pd.DataFrame:
         df = normalize_headers(df)
         df = coerce_numeric(df, PRICE_COLS, parse_price)
         df = coerce_numeric(df, PCT_COLS, parse_percent)
-        df = coerce_numeric(df, INT_COLS, lambda x: int(float(x)) if x not in (None, "", "nan") else None)
+        df = coerce_numeric(df, INT_COLS, parse_int)
         df = ensure_country_column(df)
         frames.append(df)
     if not frames:

--- a/core/transforms.py
+++ b/core/transforms.py
@@ -55,6 +55,14 @@ def parse_percent(x):
     except:
         return None
 
+def parse_int(x):
+    if x is None or x == "" or pd.isna(x):
+        return None
+    try:
+        return int(float(x))
+    except:
+        return None
+
 def coerce_numeric(df: pd.DataFrame, cols: list[str], fn) -> pd.DataFrame:
     df = df.copy()
     for c in cols:

--- a/tests/test_loaders.py
+++ b/tests/test_loaders.py
@@ -1,0 +1,22 @@
+import pandas as pd
+import numpy as np
+from io import StringIO
+import pathlib
+import sys
+
+sys.path.append(str(pathlib.Path(__file__).resolve().parents[1]))
+from core.loaders import load_many
+
+
+def test_load_many_handles_invalid_ints():
+    data = pd.DataFrame({
+        "asin": ["A", "B"],
+        "sales rank: current": [np.nan, "foo"],
+    })
+    buf = StringIO()
+    data.to_csv(buf, index=False)
+    buf.seek(0)
+    buf.name = "test.csv"
+
+    result = load_many([buf])
+    assert result["sales_rank_current"].tolist() == [None, None]


### PR DESCRIPTION
## Summary
- add `parse_int` helper to handle empty and non-numeric values
- apply `parse_int` in loaders for integer columns
- test `load_many` with NaN and invalid numeric strings

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6899f556aa18832094d81b5277f9251c