### PR TITLE
Normalize numeric inputs in _norm and add tests

### DIFF
--- a/core/features.py
+++ b/core/features.py
@@ -2,8 +2,24 @@ from __future__ import annotations
 import numpy as np
 import pandas as pd
 
+def _to_numeric(val):
+    """Convert input to numeric, replacing non-convertible values with 0."""
+    if np.isscalar(val):
+        try:
+            val = float(val)
+        except (TypeError, ValueError):
+            val = 0.0
+        return 0.0 if np.isnan(val) else val
+    val = pd.to_numeric(val, errors="coerce")
+    if hasattr(val, "fillna"):
+        return val.fillna(0)
+    return np.nan_to_num(val, nan=0.0)
+
 def _norm(x, low, high):
-    rng = max(high - low, 1e-9)
+    x = _to_numeric(x)
+    low = _to_numeric(low)
+    high = _to_numeric(high)
+    rng = np.maximum(high - low, 1e-9)
     v = (x - low) / rng
     return np.clip(v, 0.0, 1.0)
 

--- a/tests/test_features.py
+++ b/tests/test_features.py
@@ -1,0 +1,17 @@
+import pandas as pd
+import pathlib
+import sys
+
+sys.path.append(str(pathlib.Path(__file__).resolve().parents[1]))
+from core.features import _norm
+
+
+def test_norm_coerces_strings_and_invalid():
+    x = pd.Series(["1", "2", "bad", None])
+    result = _norm(x, "0", "2")
+    assert result.tolist() == [0.5, 1.0, 0.0, 0.0]
+
+
+def test_norm_handles_invalid_scalars():
+    assert _norm("bad", "0", "10") == 0.0
+    assert _norm("5", "0", "10") == 0.5


### PR DESCRIPTION
## Summary
- convert inputs in `_norm` to numeric and coerce invalid values to 0
- add tests ensuring `_norm` gracefully handles string and invalid inputs

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_689a008f8c388320b03b2c4475046054