### PR TITLE
Handle NaN bounds in feature normalization

### DIFF
--- a/core/features.py
+++ b/core/features.py
@@ -19,7 +19,12 @@ def _norm(x, low, high):
     x = _to_numeric(x)
     low = _to_numeric(low)
     high = _to_numeric(high)
-    rng = np.maximum(high - low, 1e-9)
+    diff = high - low
+    rng = np.nanmax(
+        np.stack([diff, np.full_like(diff, 1e-9, dtype=float)], axis=0), axis=0
+    )
+    if np.isscalar(rng):
+        rng = float(rng)
     v = (x - low) / rng
     return np.clip(v, 0.0, 1.0)
 

--- a/tests/test_features.py
+++ b/tests/test_features.py
@@ -15,3 +15,14 @@ def test_norm_coerces_strings_and_invalid():
 def test_norm_handles_invalid_scalars():
     assert _norm("bad", "0", "10") == 0.0
     assert _norm("5", "0", "10") == 0.5
+
+
+def test_norm_handles_nan_bounds():
+    x = pd.Series([5, 5])
+    low = pd.Series([0, 0])
+    high = pd.Series([10, float("nan")])
+    result = _norm(x, low, high)
+    assert result.tolist() == [0.5, 1.0]
+
+    assert _norm(5, 0, float("nan")) == 1.0
+    assert _norm(5, float("nan"), 10) == 0.5


### PR DESCRIPTION
## Summary
- make `_norm` range calculation NaN-safe using `np.nanmax`
- ensure scalar output for scalar ranges
- add tests covering NaN high/low bounds

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_689a032065588320bee57cfcde56b821