### PR TITLE
Fix badge attachment with missing columns

### DIFF
--- a/tests/test_arbitrage.py
+++ b/tests/test_arbitrage.py
@@ -36,3 +36,13 @@ def test_attach_badges_handles_string_inputs():
         "",
         "Low%AMZ FewSellers",
     ]
+
+
+def test_attach_badges_handles_missing_columns():
+    df = pd.DataFrame([
+        {"asin": "A1"},
+        {"asin": "A2"},
+    ])
+    result = attach_badges_for_pairs(df)
+    assert "pair_badges" in result.columns
+    assert list(result["pair_badges"]) == ["", ""]


### PR DESCRIPTION
## Summary
- Ensure `attach_badges_for_pairs` handles missing DataFrame columns without errors
- Add regression test for missing badge source columns

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_689a0a11951483209c64e54c93acbbeb